### PR TITLE
Fix: /news responsively

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfolio-v2",
   "description": "portfolio site",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "",
   "author": "Hid3xxx",
   "repository": {

--- a/src/components/News.tsx
+++ b/src/components/News.tsx
@@ -4,7 +4,7 @@ export const News = (): JSX.Element => {
   return (
     <section id="news" className="flex-grow">
       <h1 className="text-3xl font-bold">{config.news.main}</h1>
-      <div className="w-2/5 py-6">
+      <div className="md:flex md:flex-col lg:flex lg:w-1/2 lg:space-x-4 py-6">
         <a className="twitter-timeline" href="https://twitter.com/hid3xxx?ref_src=twsrc%5Etfw">
           Tweets by hid3xxx
         </a>


### PR DESCRIPTION
Fixed to display components at 50% of the page width when lg(min-width: 1024px) and to fit components to the width of the page when (max-width: 1023px).

issues: close #2 