### PR TITLE
Add Cache of ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "astro check && tsc --noEmit && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "lint": "eslint --ignore-path .gitignore src",
+    "lint": "eslint --cache --cache-location node_modules/.cache/eslint --cache-strategy content --ignore-path .gitignore src",
     "lint:fix": "eslint --ignore-path .gitignore src --fix",
     "format": "prettier --write --ignore-path .gitignore \"**/*.{astro,js,jsx,ts,tsx,cjs,mjs,json,mdx}\""
   },


### PR DESCRIPTION
The use of a cache reduces the time required for static analysis. In addition, the --cache-strategy content is set to support the use of CI in the future.